### PR TITLE
Update to nginx 1.28.0, Alpine 3.23, and add CI/CD

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -49,7 +49,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,63 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix={{branch}}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # based on the original stable alpine image
 # https://github.com/nginxinc/docker-nginx/blob/014e624239987a0a46bee5b44088a8c5150bf0bb/stable/alpine/Dockerfile
 
-FROM alpine:3.14
+FROM alpine:3.23
 
-ENV NGINX_VERSION 1.20.2
-ENV NGINX_STICKY_MODULE_NG_VERSION 08a395c66e42
+ENV NGINX_VERSION 1.28.0
+ENV NGINX_STICKY_MODULE_NG_VERSION 544beae626f20276e3ecea18395b158bd995000e
 ENV NGINX_UPSTREAM_DYNAMIC_SERVERS_VERSION master
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
@@ -50,7 +50,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	--with-file-aio \
 	--with-http_v2_module \
 	--with-cc-opt="-DNGX_HAVE_INET6=0" \
-	--add-module=/usr/src/nginx-goodies-nginx-sticky-module-ng-$NGINX_STICKY_MODULE_NG_VERSION \
+	--add-module=/usr/src/nginx_sticky_module_ng-$NGINX_STICKY_MODULE_NG_VERSION \
 	--add-module=/usr/src/nginx-upstream-dynamic-servers-$NGINX_UPSTREAM_DYNAMIC_SERVERS_VERSION \
 	" \
 	&& addgroup -S nginx \
@@ -71,7 +71,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	perl-dev \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
-	&& curl -fSL https://bitbucket.org/nginx-goodies/nginx-sticky-module-ng/get/$NGINX_STICKY_MODULE_NG_VERSION.tar.gz -o nginx-sticky-module-ng.tar.gz \
+	&& curl -fSL https://github.com/fabianofurtado/nginx_sticky_module_ng/archive/$NGINX_STICKY_MODULE_NG_VERSION.tar.gz -o nginx-sticky-module-ng.tar.gz \
 	&& curl -fSL https://github.com/DawtCom/nginx-upstream-dynamic-servers/archive/$NGINX_UPSTREAM_DYNAMIC_SERVERS_VERSION.tar.gz -o nginx-upstream-dynamic-servers.tar.gz \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& found=''; \
@@ -107,7 +107,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& strip /usr/sbin/nginx* \
 	&& strip /usr/lib/nginx/modules/*.so \
 	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
-	&& rm -rf /usr/src/nginx-goodies-nginx-sticky-module-ng-$NGINX_STICKY_MODULE_NG_VERSION \
+	&& rm -rf /usr/src/nginx_sticky_module_ng-$NGINX_STICKY_MODULE_NG_VERSION \
 	&& rm -rf /usr/src/nginx-upstream-dynamic-servers-$NGINX_UPSTREAM_DYNAMIC_SERVERS_VERSION \
 	\
 	# Bring in gettext so we can get `envsubst`, then throw

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # docker-alpine-nginx-sticky
+
+Alpine-based nginx Docker image with sticky session support and upstream dynamic servers module.
+
+## Components
+
+- **Alpine Linux**: 3.23
+- **nginx**: 1.28.0 (stable)
+- **nginx-sticky-module-ng**: [fabianofurtado/nginx_sticky_module_ng](https://github.com/fabianofurtado/nginx_sticky_module_ng) (with nginx 1.26+ compatibility patches)
+- **nginx-upstream-dynamic-servers**: [DawtCom/nginx-upstream-dynamic-servers](https://github.com/DawtCom/nginx-upstream-dynamic-servers)
+
+## Usage
+
+Pull from GitHub Container Registry:
+```bash
+docker pull ghcr.io/fuww/docker-alpine-nginx-sticky:latest
+```
+
+Or build locally:
+```bash
+docker build -t nginx-sticky .
+```
+
+## Features
+
+- Session persistence using cookies (sticky module)
+- Dynamic upstream server resolution
+- Standard nginx modules (SSL, HTTP/2, gzip, etc.)
+- IPv6 disabled for compatibility


### PR DESCRIPTION
## Summary
- Updates nginx from 1.20.2 to 1.28.0 (latest stable release as of April 2025)
- Updates Alpine Linux from 3.14 to 3.23 (latest stable release)
- Switches nginx-sticky-module to the [fabianofurtado fork](https://github.com/fabianofurtado/nginx_sticky_module_ng) which includes compatibility patches for nginx 1.26+
- Adds GitHub Actions workflow for automated multi-platform Docker builds (amd64/arm64)
- Configures automatic publishing to GitHub Container Registry (GHCR)
- Updates README with current versions and usage instructions

## Changes

### Dockerfile
- Base image: `alpine:3.14` → `alpine:3.23`
- nginx version: `1.20.2` → `1.28.0`
- Sticky module: switched from Bitbucket source to GitHub fork with modern nginx compatibility
- Module path updated to match new repository structure

### GitHub Actions Workflow
- Multi-platform builds (linux/amd64, linux/arm64)
- Automated tagging strategy (latest, semver, branch, sha)
- Build caching for faster CI runs
- Automatic GHCR publishing on push to master and tags
- PR validation (build-only, no push)

## Test Plan
- [x] Dockerfile updated with new versions
- [x] GitHub Actions workflow created
- [ ] CI build passes successfully
- [ ] Docker image runs and serves requests
- [ ] Sticky sessions work correctly
- [ ] Dynamic upstream resolution functions

## References
- [nginx 1.28.0 release](https://nginx.org/2025.html)
- [Alpine 3.23.0 release](https://www.alpinelinux.org/posts/Alpine-3.23.0-released.html)
- [nginx-sticky compatibility fork](https://github.com/fabianofurtado/nginx_sticky_module_ng)

🤖 Generated with [Claude Code](https://claude.com/claude-code)