### PR TITLE
Add Linear MCP server and slash command OPS-2163

### DIFF
--- a/.claude/commands/fix-linear-issue.md
+++ b/.claude/commands/fix-linear-issue.md
@@ -1,0 +1,14 @@
+Please analyze and fix the Linear issue: $ARGUMENTS.
+
+Follow these steps:
+
+1. Use the `mcp__linear__get_issue` MCP tool to get the issue details (pass the issue identifier, e.g. `ENG-1234`)
+2. Understand the problem described in the issue
+3. Search the codebase for relevant files
+4. Implement the necessary changes to fix the issue
+5. Write and run tests to verify the fix
+6. Ensure code passes linting and type checking
+7. Create a descriptive commit message
+8. Push and create a PR
+
+Remember to use the Linear MCP server (`mcp__linear__*` tools) for all Linear-related tasks. Linear has no official first-party CLI; the MCP tools (`get_issue`, `list_issues`, `list_comments`, `save_comment`, `save_issue`, etc.) are the equivalent of `gh issue ...`. For the final PR step, use the GitHub CLI (`gh`) as usual.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Adds the Linear MCP server (`https://mcp.linear.app/mcp`) to `.mcp.json` and the `.claude/commands/fix-linear-issue.md` slash command, so coding agents can read and update Linear issues directly.

Part of [OPS-2163](https://linear.app/fuww/issue/OPS-2163/add-linear-command-and-mcp-to-all-projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
